### PR TITLE
Pass s3Options key when creating s3-node client

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -34,7 +34,7 @@ function uploadFiles(files, config) {
     console.log("\n");
 
     let promises = [];
-    let client = s3.createClient(config.s3Options);
+    let client = s3.createClient({ s3Options: config.s3Options });
     let bar = new ProgressBar('\x1b[32mUploading Assets to S3 \x1b[0m\x1b[33m[:bar] :current/:total\x1b[0m', { total: files.length, width: 100, });
     let manifestHash = config.hasher(config.buildDir);
     


### PR DESCRIPTION
Currently the S3 options are not passed to the s3-node `createClient` method as a nested object under the `s3Options` key, although this is what is required by s3-node (see https://github.com/ncnipunchawla/node-s3-client#create-a-client). This PR fixes that.